### PR TITLE
Support non-interactive and file input for the `explain` command

### DIFF
--- a/packages/upg/README.md
+++ b/packages/upg/README.md
@@ -191,4 +191,16 @@ The following explanation was generated:
       **Save** to get it out of the CLI and execute it manually, or load it with
       `upg load [new-file]` and then **Run**.
 
-      See the **Convert to other languages** section above.
+      See the **Convert to other languages** section above .
+
+## Local development
+
+Run `npm install` at the mono-repo level, then run `npm install` in this package.
+
+After that, build the binary with `npm run build` and then run it with `node dist/bin.js` with whatever command-line arguments you want to test. You may have to login again.
+
+```shell
+node dist/bin.js login
+echo 'console.log("hello world")' > /tmp/hello.ts
+node dist/bin.js explain -n /tmp/hello.ts
+```

--- a/packages/upg/src/bin.ts
+++ b/packages/upg/src/bin.ts
@@ -41,7 +41,8 @@ program
 program
   .command("explain")
   .description("Explain a program by pasting it or loading from file.\n\n")
-  // .option("-f, --file [file]", "The file to explain.")
+  .option("-n, --non-interactive", "Run without interactivity.")
+  .argument("[file]", "The file to explain.")
   .action(withErrorFormatting(explainCommand));
 
 

--- a/packages/upg/src/commands/explain.ts
+++ b/packages/upg/src/commands/explain.ts
@@ -4,8 +4,28 @@ import prompts from "prompts";
 import { explain } from "../actions/explain";
 import { loop } from "../state";
 import { log } from "@tsmodule/log";
+import {extname} from "path";
+import {readFile} from "fs/promises";
 
-export const explainCommand = async () => {
+export type ExplainOptions = {
+  nonInteractive?: boolean;
+};
+
+export const explainCommand = async (
+  file: string,
+  { nonInteractive = false }: ExplainOptions
+) => {
+  if (nonInteractive) {
+    if (!file) {
+      throw new Error("Specify `file` for --non-interactive mode.");
+    }
+    const target = extname(file).slice(1);
+    const fileContents = await readFile(file, "utf8");
+    const state = await explain({ code: fileContents, target });
+    log(state.explanation);
+    return;
+  }
+
   const code: string = await new Promise((resolve, reject) => {
     editor("")
       .on("submit", resolve)


### PR DESCRIPTION
* The option `-n`, `--non-interactive` can be used with the explain command.
* The input file is *required* when in non-interactive mode.

After reading the file, sends it to `explain` and prints out the explanation.

In addition, the README was updated to explain how to build the program locally and how to test it (with this particular explain command).

```shell
echo 'console.log("hello world")' > /tmp/hello.ts
upg explain -n /tmp/hello.ts
```